### PR TITLE
force theme to be dark, ignore system theme

### DIFF
--- a/src/components/theme/ThemeProvider.tsx
+++ b/src/components/theme/ThemeProvider.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider } from 'next-themes'
 
 export default function Theme({ children }: { children: React.ReactNode }) {
   return (
-    <ThemeProvider attribute="class">
+    <ThemeProvider enableSystem={false} defaultTheme={"dark"} attribute="class">
       {children}
     </ThemeProvider>
   )


### PR DESCRIPTION
Force theme of site to default to being dark, ignoring system preference (since this is my website and I prefer it in dark and I think others should see it as dark too)

Also removes the extra click that is required to change it into light mode, since I was doing scuffed things to force dark mode before.